### PR TITLE
Azurite HTTPS Implement support for dotnet dev-certs

### DIFF
--- a/src/blob/BlobEnvironment.ts
+++ b/src/blob/BlobEnvironment.ts
@@ -6,7 +6,7 @@ import { promisify } from "util";
 import IBlobEnvironment from "./IBlobEnvironment";
 import {
   DEFAULT_BLOB_LISTENING_PORT,
-  DEFAULT_BLOB_SERVER_HOST_NAME
+  DEFAULT_BLOB_SERVER_HOST_NAME,
 } from "./utils/constants";
 
 const accessAsync = promisify(access);
@@ -42,7 +42,8 @@ if (!(args as any).config.name) {
       ["d", "debug"],
       "Optional. Enable debug log by providing a valid local file path as log destination"
     )
-    .option(["", "pwd"], "Optional. Password for .pfx file.");
+    .option(["", "pwd"], "Optional. Password for .pfx file.")
+    .option(["", "https"], "Optional. Use default HTTPS mode");
 
   (args as any).config.name = "azurite-blob";
 }
@@ -89,6 +90,10 @@ export default class BlobEnvironment implements IBlobEnvironment {
 
   public pwd(): string | undefined {
     return this.flags.pwd;
+  }
+
+  public https(): string | undefined {
+    return this.flags.https;
   }
 
   public async debug(): Promise<string | undefined> {

--- a/src/blob/BlobEnvironment.ts
+++ b/src/blob/BlobEnvironment.ts
@@ -6,7 +6,7 @@ import { promisify } from "util";
 import IBlobEnvironment from "./IBlobEnvironment";
 import {
   DEFAULT_BLOB_LISTENING_PORT,
-  DEFAULT_BLOB_SERVER_HOST_NAME,
+  DEFAULT_BLOB_SERVER_HOST_NAME
 } from "./utils/constants";
 
 const accessAsync = promisify(access);

--- a/src/common/ConfigurationBase.ts
+++ b/src/common/ConfigurationBase.ts
@@ -4,7 +4,7 @@ import * as child_process from "child_process";
 export enum CertOptions {
   Default,
   PEM,
-  PFX,
+  PFX
 }
 
 export default abstract class ConfigurationBase {
@@ -59,12 +59,12 @@ export default abstract class ConfigurationBase {
       case CertOptions.PEM:
         return {
           cert: fs.readFileSync(this.cert),
-          key: fs.readFileSync(this.key),
+          key: fs.readFileSync(this.key)
         };
       case CertOptions.PFX:
         return {
           pfx: fs.readFileSync(this.cert),
-          passphrase: this.pwd.toString(),
+          passphrase: this.pwd.toString()
         };
       default:
         return null;
@@ -72,7 +72,7 @@ export default abstract class ConfigurationBase {
   }
 
   public getHttpServerAddress(): string {
-    return `http${this.hasCert() == CertOptions.Default ? "" : "s"}://${
+    return `http${this.hasCert() === CertOptions.Default ? "" : "s"}://${
       this.host
     }:${this.port}`;
   }

--- a/src/common/ConfigurationBase.ts
+++ b/src/common/ConfigurationBase.ts
@@ -1,5 +1,5 @@
-const fs = require("fs");
 import * as child_process from "child_process";
+import * as fs from "fs";
 
 export enum CertOptions {
   Default,

--- a/src/common/Environment.ts
+++ b/src/common/Environment.ts
@@ -2,11 +2,11 @@ import args from "args";
 
 import {
   DEFAULT_BLOB_LISTENING_PORT,
-  DEFAULT_BLOB_SERVER_HOST_NAME,
+  DEFAULT_BLOB_SERVER_HOST_NAME
 } from "../blob/utils/constants";
 import {
   DEFAULT_QUEUE_LISTENING_PORT,
-  DEFAULT_QUEUE_SERVER_HOST_NAME,
+  DEFAULT_QUEUE_SERVER_HOST_NAME
 } from "../queue/utils/constants";
 import IEnvironment from "./IEnvironment";
 

--- a/src/common/Environment.ts
+++ b/src/common/Environment.ts
@@ -2,11 +2,11 @@ import args from "args";
 
 import {
   DEFAULT_BLOB_LISTENING_PORT,
-  DEFAULT_BLOB_SERVER_HOST_NAME
+  DEFAULT_BLOB_SERVER_HOST_NAME,
 } from "../blob/utils/constants";
 import {
   DEFAULT_QUEUE_LISTENING_PORT,
-  DEFAULT_QUEUE_SERVER_HOST_NAME
+  DEFAULT_QUEUE_SERVER_HOST_NAME,
 } from "../queue/utils/constants";
 import IEnvironment from "./IEnvironment";
 
@@ -44,6 +44,7 @@ args
   .option(["", "cert"], "Optional. Path to certificate file.")
   .option(["", "key"], "Optional. Path to certificate key .pem file.")
   .option(["", "pwd"], "Optional. Password for .pfx file.")
+  .option(["", "https"], "Optional. Use default HTTPS mode")
   .option(
     ["d", "debug"],
     "Optional. Enable debug log by providing a valid local file path as log destination"
@@ -99,6 +100,10 @@ export default class Environment implements IEnvironment {
 
   public pwd(): string | undefined {
     return this.flags.pwd;
+  }
+
+  public https(): string | undefined {
+    return this.flags.https;
   }
 
   public async debug(): Promise<string | undefined> {

--- a/src/queue/QueueEnvironment.ts
+++ b/src/queue/QueueEnvironment.ts
@@ -3,7 +3,7 @@ import args from "args";
 import IQueueEnvironment from "./IQueueEnvironment";
 import {
   DEFAULT_QUEUE_LISTENING_PORT,
-  DEFAULT_QUEUE_SERVER_HOST_NAME
+  DEFAULT_QUEUE_SERVER_HOST_NAME,
 } from "./utils/constants";
 
 args
@@ -30,6 +30,7 @@ args
   .option(["", "cert"], "Optional. Path to certificate file.")
   .option(["", "key"], "Optional. Path to certificate key .pem file.")
   .option(["", "pwd"], "Optional. Password for .pfx file.")
+  .option(["", "https"], "Optional. Use default HTTPS mode")
   .option(
     ["d", "debug"],
     "Optional. Enable debug log by providing a valid local file path as log destination"
@@ -77,6 +78,10 @@ export default class QueueEnvironment implements IQueueEnvironment {
 
   public pwd(): string | undefined {
     return this.flags.pwd;
+  }
+
+  public https(): string | undefined {
+    return this.flags.https;
   }
 
   public async debug(): Promise<string | undefined> {

--- a/src/queue/QueueEnvironment.ts
+++ b/src/queue/QueueEnvironment.ts
@@ -3,7 +3,7 @@ import args from "args";
 import IQueueEnvironment from "./IQueueEnvironment";
 import {
   DEFAULT_QUEUE_LISTENING_PORT,
-  DEFAULT_QUEUE_SERVER_HOST_NAME,
+  DEFAULT_QUEUE_SERVER_HOST_NAME
 } from "./utils/constants";
 
 args


### PR DESCRIPTION
Azurite HTTPS against dotnet dev-certs commands:
User installs the cert.
**dotnet dev-certs install --trust**
User only has to pass https to Azurite and it knows to find the cert created with dev-cert
**azurite https**