### PR TITLE
Azurite HTTPS Implement support for dotnet dev-certs

### DIFF
--- a/src/azurite.ts
+++ b/src/azurite.ts
@@ -59,7 +59,8 @@ async function main() {
     env.loose(),
     env.cert(),
     env.key(),
-    env.pwd()
+    env.pwd(),
+    env.https()
   );
 
   // We use logger singleton as global debugger logger to track detailed outputs cross layers

--- a/src/blob/BlobConfiguration.ts
+++ b/src/blob/BlobConfiguration.ts
@@ -36,7 +36,8 @@ export default class BlobConfiguration extends ConfigurationBase {
     loose: boolean = false,
     cert: string = "",
     key: string = "",
-    pwd: string = ""
+    pwd: string = "",
+    https: boolean = false
   ) {
     super(
       host,
@@ -48,7 +49,8 @@ export default class BlobConfiguration extends ConfigurationBase {
       loose,
       cert,
       key,
-      pwd
+      pwd,
+      https
     );
   }
 }

--- a/src/blob/BlobEnvironment.ts
+++ b/src/blob/BlobEnvironment.ts
@@ -92,7 +92,10 @@ export default class BlobEnvironment implements IBlobEnvironment {
     return this.flags.pwd;
   }
 
-  public https(): string | undefined {
+  public https(): boolean {
+    if (process.argv.includes("https")) {
+      return true;
+    }
     return this.flags.https;
   }
 

--- a/src/blob/BlobEnvironment.ts
+++ b/src/blob/BlobEnvironment.ts
@@ -6,7 +6,7 @@ import { promisify } from "util";
 import IBlobEnvironment from "./IBlobEnvironment";
 import {
   DEFAULT_BLOB_LISTENING_PORT,
-  DEFAULT_BLOB_SERVER_HOST_NAME
+  DEFAULT_BLOB_SERVER_HOST_NAME,
 } from "./utils/constants";
 
 const accessAsync = promisify(access);
@@ -42,7 +42,8 @@ if (!(args as any).config.name) {
       ["d", "debug"],
       "Optional. Enable debug log by providing a valid local file path as log destination"
     )
-    .option(["", "pwd"], "Optional. Password for .pfx file.");
+    .option(["", "pwd"], "Optional. Password for .pfx file.")
+    .option(["", "https"], "Optional. Use default HTTPS mode");
 
   (args as any).config.name = "azurite-blob";
 }
@@ -89,6 +90,10 @@ export default class BlobEnvironment implements IBlobEnvironment {
 
   public pwd(): string | undefined {
     return this.flags.pwd;
+  }
+
+  public https(): string | undefined {
+    return this.flags.https;
   }
 
   public async debug(): Promise<string | undefined> {

--- a/src/blob/BlobEnvironment.ts
+++ b/src/blob/BlobEnvironment.ts
@@ -6,7 +6,7 @@ import { promisify } from "util";
 import IBlobEnvironment from "./IBlobEnvironment";
 import {
   DEFAULT_BLOB_LISTENING_PORT,
-  DEFAULT_BLOB_SERVER_HOST_NAME,
+  DEFAULT_BLOB_SERVER_HOST_NAME
 } from "./utils/constants";
 
 const accessAsync = promisify(access);

--- a/src/blob/BlobServerFactory.ts
+++ b/src/blob/BlobServerFactory.ts
@@ -70,7 +70,8 @@ export class BlobServerFactory {
           env.loose(),
           env.cert(),
           env.key(),
-          env.pwd()
+          env.pwd(),
+          env.https()
         );
         return new BlobServer(config);
       }

--- a/src/blob/IBlobEnvironment.ts
+++ b/src/blob/IBlobEnvironment.ts
@@ -7,5 +7,6 @@ export default interface IBlobEnvironment {
   cert(): string | undefined;
   key(): string | undefined;
   pwd(): string | undefined;
+  https(): boolean;
   debug(): Promise<string | boolean | undefined>;
 }

--- a/src/common/ConfigurationBase.ts
+++ b/src/common/ConfigurationBase.ts
@@ -23,21 +23,15 @@ export default abstract class ConfigurationBase {
   ) {}
 
   public exportCert() {
-    return new Promise((resolve, reject) => {
-      this.pwd = "123456";
-      this.cert = "azurite.pfx";
-      const certName = "localhost";
-      try {
-        child_process.exec(
-          `CertUtil -p ${this.pwd} -exportPFX -user ${certName} azurite.pfx`,
-          (error, stdout, stderr) => {
-            resolve({ stdout, stderr });
-          }
-        );
-      } catch (err) {
-        reject(err);
-      }
-    });
+    const pwd = "123456";
+    const certName = "localhost";
+    try {
+      child_process.execSync(
+        `CertUtil -p ${pwd} -exportPFX -user ${certName} azurite.pfx`
+      );
+    } catch (err) {
+      console.log(err);
+    }
   }
 
   public hasCert() {
@@ -48,7 +42,12 @@ export default abstract class ConfigurationBase {
       return CertOptions.PFX;
     }
     if (this.https) {
-      return this.exportCert().then(() => CertOptions.PFX);
+      this.pwd = "123456";
+      this.cert = "azurite.pfx";
+      if (!fs.existsSync("azurite.pfx")) {
+        this.exportCert();
+      }
+      return CertOptions.PFX;
     }
 
     return CertOptions.Default;

--- a/src/common/ConfigurationBase.ts
+++ b/src/common/ConfigurationBase.ts
@@ -4,7 +4,7 @@ import * as child_process from "child_process";
 export enum CertOptions {
   Default,
   PEM,
-  PFX,
+  PFX
 }
 
 export default abstract class ConfigurationBase {
@@ -59,12 +59,12 @@ export default abstract class ConfigurationBase {
       case CertOptions.PEM:
         return {
           cert: fs.readFileSync(this.cert),
-          key: fs.readFileSync(this.key),
+          key: fs.readFileSync(this.key)
         };
       case CertOptions.PFX:
         return {
           pfx: fs.readFileSync(this.cert),
-          passphrase: this.pwd.toString(),
+          passphrase: this.pwd.toString()
         };
       default:
         return null;
@@ -72,7 +72,7 @@ export default abstract class ConfigurationBase {
   }
 
   public getHttpServerAddress(): string {
-    return `http${this.hasCert() == CertOptions.Default ? "" : "s"}://${
+    return `http${this.hasCert() === CertOptions.Default ? "" : "s"}://${
       this.host
     }:${this.port}`;
   }

--- a/src/common/ConfigurationBase.ts
+++ b/src/common/ConfigurationBase.ts
@@ -19,7 +19,7 @@ export default abstract class ConfigurationBase {
     public cert: string = "",
     public readonly key: string = "",
     public pwd: string = "",
-    public readonly https: boolean = true
+    public readonly https: boolean = false
   ) {}
 
   public hasCert() {
@@ -39,7 +39,7 @@ export default abstract class ConfigurationBase {
             `CertUtil -p ${this.pwd} -exportPFX -user ${certName} azurite.pfx`
           );
         } catch (err) {
-          console.log(
+          throw new Error(
             "Please run 'dotnet dev-certs https --trust' to install certificate."
           );
         }

--- a/src/common/ConfigurationBase.ts
+++ b/src/common/ConfigurationBase.ts
@@ -1,5 +1,5 @@
-const fs = require("fs");
 import * as child_process from "child_process";
+import * as fs from "fs";
 
 export enum CertOptions {
   Default,

--- a/src/common/ConfigurationBase.ts
+++ b/src/common/ConfigurationBase.ts
@@ -22,18 +22,6 @@ export default abstract class ConfigurationBase {
     public readonly https: boolean = true
   ) {}
 
-  public exportCert() {
-    const pwd = "123456";
-    const certName = "localhost";
-    try {
-      child_process.execSync(
-        `CertUtil -p ${pwd} -exportPFX -user ${certName} azurite.pfx`
-      );
-    } catch (err) {
-      console.log(err);
-    }
-  }
-
   public hasCert() {
     if (this.cert.length > 0 && this.key.length > 0) {
       return CertOptions.PEM;
@@ -45,7 +33,16 @@ export default abstract class ConfigurationBase {
       this.pwd = "123456";
       this.cert = "azurite.pfx";
       if (!fs.existsSync("azurite.pfx")) {
-        this.exportCert();
+        const certName = "localhost";
+        try {
+          child_process.execSync(
+            `CertUtil -p ${this.pwd} -exportPFX -user ${certName} azurite.pfx`
+          );
+        } catch (err) {
+          console.log(
+            "Please run 'dotnet dev-certs https --trust' to install certificate."
+          );
+        }
       }
       return CertOptions.PFX;
     }

--- a/src/common/Environment.ts
+++ b/src/common/Environment.ts
@@ -102,7 +102,10 @@ export default class Environment implements IEnvironment {
     return this.flags.pwd;
   }
 
-  public https(): string | undefined {
+  public https(): boolean {
+    if (process.argv.includes("https")) {
+      return true;
+    }
     return this.flags.https;
   }
 

--- a/src/common/Environment.ts
+++ b/src/common/Environment.ts
@@ -2,11 +2,11 @@ import args from "args";
 
 import {
   DEFAULT_BLOB_LISTENING_PORT,
-  DEFAULT_BLOB_SERVER_HOST_NAME,
+  DEFAULT_BLOB_SERVER_HOST_NAME
 } from "../blob/utils/constants";
 import {
   DEFAULT_QUEUE_LISTENING_PORT,
-  DEFAULT_QUEUE_SERVER_HOST_NAME,
+  DEFAULT_QUEUE_SERVER_HOST_NAME
 } from "../queue/utils/constants";
 import IEnvironment from "./IEnvironment";
 

--- a/src/common/Environment.ts
+++ b/src/common/Environment.ts
@@ -2,11 +2,11 @@ import args from "args";
 
 import {
   DEFAULT_BLOB_LISTENING_PORT,
-  DEFAULT_BLOB_SERVER_HOST_NAME
+  DEFAULT_BLOB_SERVER_HOST_NAME,
 } from "../blob/utils/constants";
 import {
   DEFAULT_QUEUE_LISTENING_PORT,
-  DEFAULT_QUEUE_SERVER_HOST_NAME
+  DEFAULT_QUEUE_SERVER_HOST_NAME,
 } from "../queue/utils/constants";
 import IEnvironment from "./IEnvironment";
 
@@ -44,6 +44,7 @@ args
   .option(["", "cert"], "Optional. Path to certificate file.")
   .option(["", "key"], "Optional. Path to certificate key .pem file.")
   .option(["", "pwd"], "Optional. Password for .pfx file.")
+  .option(["", "https"], "Optional. Use default HTTPS mode")
   .option(
     ["d", "debug"],
     "Optional. Enable debug log by providing a valid local file path as log destination"
@@ -99,6 +100,10 @@ export default class Environment implements IEnvironment {
 
   public pwd(): string | undefined {
     return this.flags.pwd;
+  }
+
+  public https(): string | undefined {
+    return this.flags.https;
   }
 
   public async debug(): Promise<string | undefined> {

--- a/src/common/VSCEnvironment.ts
+++ b/src/common/VSCEnvironment.ts
@@ -86,4 +86,8 @@ export default class VSCEnvironment implements IEnvironment {
   public pwd(): string | undefined {
     return this.workspaceConfiguration.get<string>("pwd");
   }
+
+  public https(): boolean {
+    return this.workspaceConfiguration.get<boolean>("https") || false;
+  }
 }

--- a/src/queue/IQueueEnvironment.ts
+++ b/src/queue/IQueueEnvironment.ts
@@ -7,5 +7,6 @@ export default interface IQueueEnvironment {
   cert(): string | undefined;
   key(): string | undefined;
   pwd(): string | undefined;
+  https(): boolean;
   debug(): Promise<string | boolean | undefined>;
 }

--- a/src/queue/QueueConfiguration.ts
+++ b/src/queue/QueueConfiguration.ts
@@ -36,7 +36,8 @@ export default class QueueConfiguration extends ConfigurationBase {
     loose: boolean = false,
     cert: string = "",
     key: string = "",
-    pwd: string = ""
+    pwd: string = "",
+    https: boolean = false
   ) {
     super(
       host,
@@ -48,7 +49,8 @@ export default class QueueConfiguration extends ConfigurationBase {
       loose,
       cert,
       key,
-      pwd
+      pwd,
+      https
     );
   }
 }

--- a/src/queue/QueueEnvironment.ts
+++ b/src/queue/QueueEnvironment.ts
@@ -3,7 +3,7 @@ import args from "args";
 import IQueueEnvironment from "./IQueueEnvironment";
 import {
   DEFAULT_QUEUE_LISTENING_PORT,
-  DEFAULT_QUEUE_SERVER_HOST_NAME
+  DEFAULT_QUEUE_SERVER_HOST_NAME,
 } from "./utils/constants";
 
 args
@@ -30,6 +30,7 @@ args
   .option(["", "cert"], "Optional. Path to certificate file.")
   .option(["", "key"], "Optional. Path to certificate key .pem file.")
   .option(["", "pwd"], "Optional. Password for .pfx file.")
+  .option(["", "https"], "Optional. Use default HTTPS mode")
   .option(
     ["d", "debug"],
     "Optional. Enable debug log by providing a valid local file path as log destination"
@@ -77,6 +78,10 @@ export default class QueueEnvironment implements IQueueEnvironment {
 
   public pwd(): string | undefined {
     return this.flags.pwd;
+  }
+
+  public https(): string | undefined {
+    return this.flags.https;
   }
 
   public async debug(): Promise<string | undefined> {

--- a/src/queue/QueueEnvironment.ts
+++ b/src/queue/QueueEnvironment.ts
@@ -3,7 +3,7 @@ import args from "args";
 import IQueueEnvironment from "./IQueueEnvironment";
 import {
   DEFAULT_QUEUE_LISTENING_PORT,
-  DEFAULT_QUEUE_SERVER_HOST_NAME,
+  DEFAULT_QUEUE_SERVER_HOST_NAME
 } from "./utils/constants";
 
 args

--- a/src/queue/QueueEnvironment.ts
+++ b/src/queue/QueueEnvironment.ts
@@ -80,7 +80,10 @@ export default class QueueEnvironment implements IQueueEnvironment {
     return this.flags.pwd;
   }
 
-  public https(): string | undefined {
+  public https(): boolean {
+    if (process.argv.includes("https")) {
+      return true;
+    }
     return this.flags.https;
   }
 


### PR DESCRIPTION
Azurite HTTPS against dotnet dev-certs commands:
User installs the cert.
**dotnet dev-certs install --trust**
User only has to pass https to Azurite and it knows to find the cert created with dev-cert
**azurite https**